### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v1.3.34
+v1.3.34 
 - Now always shows your drive entries in the host db file if -s or --showedits used instead of only db file was edited during that run.
 - Changed to show usage if invalid long option used instead of continuing.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v1.3.34
+- Now always shows your drive entries in the host db file if -s or --showedits used instead of only db file was edited during that run.
+- Changed to show usage if invalid long option used instead of continuing.
+
 v1.3.33
 -  Fixed bug inserting firmware version for already existing model.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v1.3.34 
+v1.3.34
 - Now always shows your drive entries in the host db file if -s or --showedits used instead of only db file was edited during that run.
 - Changed to show usage if invalid long option used instead of continuing.
 


### PR DESCRIPTION
- Now always shows your drive entries in the host db file if -s or --showedits used instead of only db file was edited during that run.
- Changed to show usage if invalid long option used instead of continuing.