### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+v2.1.38
+- Improved shell output when editing max memory setting.
+- Changed method of checking if drive is a USB drive to prevent ignoring internal drives on RS models.
+- Changed to not run "synostgdisk --check-all-disks-compatibility" in DSM 6.2.3 (which has no synostgdisk).
+
 v2.1.37
 - Now edits max supported memory to match the amount of memory installed, if installed memory is greater than the current max memory setting.
 - Minor improvements.

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -30,11 +30,11 @@
 # It's also parsed and checked and probably in some cases it could be more critical to patch that one instead.
 
 # DONE
-# Changed method of checking if drive is a USB drive to prevent ignoring internal drives on RS models.
-#
 # Improved shell output when editing max memory setting.
 #
-# Changed to not run "synostgdisk --check-all-disks-compatibility" in DSM 6.2.3 (which has no synostgdisk.
+# Changed method of checking if drive is a USB drive to prevent ignoring internal drives on RS models.
+#
+# Changed to not run "synostgdisk --check-all-disks-compatibility" in DSM 6.2.3 (which has no synostgdisk).
 #
 # Now edits max supported memory to match the amount of memory installed, if greater than the current max memory setting.
 #


### PR DESCRIPTION
- Improved shell output when editing max memory setting.
- Changed method of checking if drive is a USB drive to prevent ignoring internal drives on RS models.
- Changed to not run "synostgdisk --check-all-disks-compatibility" in DSM 6.2.3 (which has no synostgdisk).