### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v2.2.41
+- Fixed bug where expansion units ending in RP or II were not detected.
+
 v2.2.40
 - Added a --restore option to undo all changes made by the script.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v2.2.40
+- Added a --restore option to undo all changes.
+
 v2.2.39
 - Now looks for and edits both v7 and non-v7 db files to solve issue #11 for RS '21 models running DSM 6.2.4. This will also ensure the script still works if:
     - Synology append different numbers to the db file names in DSM 8 etc.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v2.2.39
+- Now looks for and edits both v7 and non-v7 db files to solve issue #11 for RS '21 models running DSM 6.2.4.
+
 v2.1.38
 - Improved shell output when editing max memory setting.
 - Changed method of checking if drive is a USB drive to prevent ignoring internal drives on RS models.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 v2.2.40
-- Added a --restore option to undo all changes.
+- Added a --restore option to undo all changes made by the script.
 
 v2.2.39
 - Now looks for and edits both v7 and non-v7 db files to solve issue #11 for RS '21 models running DSM 6.2.4. This will also ensure the script still works if:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,6 @@
-v2.2.41
+v2.2.42
 - Fixed bug where expansion units ending in RP or II were not detected.
-
-v2.2.40
 - Added a --restore option to undo all changes made by the script.
-
-v2.2.39
 - Now looks for and edits both v7 and non-v7 db files to solve issue #11 for RS '21 models running DSM 6.2.4. This will also ensure the script still works if:
     - Synology append different numbers to the db file names in DSM 8 etc.
     - The detected NAS model name does not match the .db files' model name.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,11 @@
 v2.2.39
-- Now looks for and edits both v7 and non-v7 db files to solve issue #11 for RS '21 models running DSM 6.2.4.
+- Now looks for and edits both v7 and non-v7 db files to solve issue #11 for RS '21 models running DSM 6.2.4. This will also ensure the script still works if:
+    - Synology append different numbers to the db file names in DSM 8 etc.
+    - The detected NAS model name does not match the .db files' model name.
+- Now backs up the .db.new files (as well as the .db files).
+- Now shows max memory in GB instead of MB.
+- Now shows status of "Support disk compatibility" setting even if it wasn't changed.
+- Now shows status of "Support memory compatibility" setting even if it wasn't changed.
 
 v2.1.38
 - Improved shell output when editing max memory setting.

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -30,6 +30,8 @@
 # It's also parsed and checked and probably in some cases it could be more critical to patch that one instead.
 
 # DONE
+# Fixed bug where expansion units ending in RP or II were not detected.
+#
 # Added a --restore option to undo all changes.
 #
 # Now looks for and edits both v7 and non-v7 db files to solve issue #11 for RS '21 models running DSM 6.2.4.
@@ -137,7 +139,7 @@
 # Optionally disable "support_disk_compatibility".
 
 
-scriptver="v2.2.40"
+scriptver="v2.2.41"
 script=Synology_HDD_db
 repo="007revad/Synology_HDD_db"
 
@@ -685,8 +687,8 @@ fi
 # Get list of connected expansion units (aka eunit/ebox)
 path="/var/log/diskprediction"
 # shellcheck disable=SC2012
-file=$(ls $path | tail -n1) 
-eunitlist=($(grep -Eow "([FRD]XD?[0-9]{3,4})(RP|II|sas){0,2}" "$path/$file" | uniq))
+file=$(ls $path | tail -n1)
+eunitlist=($(grep -Eowi "([FRD]XD?[0-9]{3,4})(rp|ii|sas){0,2}" "$path/$file" | uniq))
 
 # Sort eunitlist array into new eunits array to remove duplicates
 if [[ ${#eunitlist[@]} -gt "0" ]]; then

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -47,7 +47,6 @@
 #
 # Now shows status of "Support memory compatibility" setting even if it wasn't changed.
 #
-#
 # Improved shell output when editing max memory setting.
 #
 # Changed method of checking if drive is a USB drive to prevent ignoring internal drives on RS models.
@@ -139,7 +138,7 @@
 # Optionally disable "support_disk_compatibility".
 
 
-scriptver="v2.2.41"
+scriptver="v2.2.42"
 script=Synology_HDD_db
 repo="007revad/Synology_HDD_db"
 


### PR DESCRIPTION
- Fixed bug where expansion units ending in RP or II were not detected.
- Added a --restore option to undo all changes made by the script.
- Now looks for and edits both v7 and non-v7 db files to solve issue #11 for RS '21 models running DSM 6.2.4. This will also ensure the script still works if:
    - Synology append different numbers to the db file names in DSM 8 etc.
    - The detected NAS model name does not match the .db files' model name.
- Now backs up the .db.new files (as well as the .db files).
- Now shows max memory in GB instead of MB.
- Now shows status of "Support disk compatibility" setting even if it wasn't changed.
- Now shows status of "Support memory compatibility" setting even if it wasn't changed.