### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+v2.3.48
+- Now the script reloads itself after updating.
+- Added --autoupdate=[age] option to auto update synology_hdd_db x days after new version released.
+    - Autoupdate adds success/failed entry to the DSM system log.
+- Added -w, --wdda option to disable WDDA.
+
 v2.2.47
 - Updated reboot info in readme.
 - Added reboot message for DSM 7.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,15 @@
-v2.3.48
+v2.3.49
+- Fixed HDD/SSD firmware versions always being 4 characters long (for DSM 7.2 and 6.2.4 Update 7).
+- Fixed detecting amount of installed memory (for DSM 7.2 which now reports GB instead of MB).
+- Fixed USB drives sometimes being detected as internal drives (for DSM 7.2).
+- Fixed error if /run/synostorage/disks/nvme0n1/m2_pool_support doesn't exist yet (for DSM 7.2).
+- Fixed drive db update still being disabled in /etc/synoinfo.conf after script run without -n or --noupdate option.
+- Fixed drive db update still being disabled in /etc/synoinfo.conf after script run with --restore option.
+- Fixed permissions on restored files being incorrect after script run with --restore option.
+- Fixed permissions on backup files.
+- Now skips checking the amount of installed memory in DSM 6 (because it was never working).
 - Now the script reloads itself after updating.
+- Added "You may need to reboot" message when NVMe drives were detected.
 - Added --autoupdate=[age] option to auto update synology_hdd_db x days after new version released.
     - Autoupdate logs update success or errors to DSM system log.
 - Added -w, --wdda option to disable WDDA.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v2.3.51
+v2.3.52
 - Fixed HDD/SSD firmware versions always being 4 characters long (for DSM 7.2 and 6.2.4 Update 7).
 - Fixed detecting amount of installed memory (for DSM 7.2 which now reports GB instead of MB).
 - Fixed USB drives sometimes being detected as internal drives (for DSM 7.2).
@@ -7,8 +7,9 @@ v2.3.51
 - Fixed drive db update still being disabled in /etc/synoinfo.conf after script run with --restore option.
 - Fixed permissions on restored files being incorrect after script run with --restore option.
 - Fixed permissions on backup files.
-- Now skips checking the amount of installed memory in DSM 6 (because it was never working).
+- Now skips checking the amount of installed memory in DSM 6 (because it was never working in DSM 6).
 - Now the script reloads itself after updating.
+- Changed the "No M.2 cards found" to "No M.2 PCIe cards found" to make it clearer.
 - Added "You may need to reboot" message when NVMe drives were detected.
 - Added --autoupdate=[age] option to auto update synology_hdd_db x days after new version released.
     - Autoupdate logs update success or errors to DSM system log.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 v2.3.48
 - Now the script reloads itself after updating.
 - Added --autoupdate=[age] option to auto update synology_hdd_db x days after new version released.
-    - Autoupdate adds success/failed entry to the DSM system log.
+    - Autoupdate logs update success or errors to DSM system log.
 - Added -w, --wdda option to disable WDDA.
 
 v2.2.47

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v2.3.50
+v2.3.51
 - Fixed HDD/SSD firmware versions always being 4 characters long (for DSM 7.2 and 6.2.4 Update 7).
 - Fixed detecting amount of installed memory (for DSM 7.2 which now reports GB instead of MB).
 - Fixed USB drives sometimes being detected as internal drives (for DSM 7.2).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,15 @@
-v2.3.54
+v3.0.55
+- Now enables any installed Synology M.2 PCIe cards for models that don't officially support them.
+  - You can use a M2D20, M2D18, M2D17 or E10M20-T1 on any model with a PCIe slot (not Mini PCIe).
+- Now the script reloads itself after updating.
+- Added -i, --immutable option to enable immutable snapshots on models older than '20 series running DSM 7.2.
+- Added -w, --wdda option to disable WDDA (to prevent warnings when WD drives have been running more than 3 years).
+- Added "You may need to reboot" message when NVMe drives were detected.
+- Added --autoupdate=[age] option to auto update synology_hdd_db x days after new version released.
+    - Autoupdate logs update success or errors to DSM system log.
+- Changed help to show -r, --ram also sets max memory to the amount of installed memory.
+- Changed the "No M.2 cards found" to "No M.2 PCIe cards found" to make it clearer.
+- Changed to skip checking the amount of installed memory in DSM 6 (because it was never working in DSM 6).
 - Fixed HDD/SSD firmware versions always being 4 characters long (for DSM 7.2 and 6.2.4 Update 7).
 - Fixed detecting amount of installed memory (for DSM 7.2 which now reports GB instead of MB).
 - Fixed USB drives sometimes being detected as internal drives (for DSM 7.2).
@@ -7,14 +18,6 @@ v2.3.54
 - Fixed drive db update still being disabled in /etc/synoinfo.conf after script run with --restore option.
 - Fixed permissions on restored files being incorrect after script run with --restore option.
 - Fixed permissions on backup files.
-- Now skips checking the amount of installed memory in DSM 6 (because it was never working in DSM 6).
-- Now the script reloads itself after updating.
-- Changed help to show -r, --ram also sets max memory to the amount of installed memory.
-- Changed the "No M.2 cards found" to "No M.2 PCIe cards found" to make it clearer.
-- Added "You may need to reboot" message when NVMe drives were detected.
-- Added --autoupdate=[age] option to auto update synology_hdd_db x days after new version released.
-    - Autoupdate logs update success or errors to DSM system log.
-- Added -w, --wdda option to disable WDDA.
 
 v2.2.47
 - Updated reboot info in readme.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ v2.3.53
 - Fixed permissions on backup files.
 - Now skips checking the amount of installed memory in DSM 6 (because it was never working in DSM 6).
 - Now the script reloads itself after updating.
+- Changed help to show -r, --ram also sets max memory to the amount of installed memory.
 - Changed the "No M.2 cards found" to "No M.2 PCIe cards found" to make it clearer.
 - Added "You may need to reboot" message when NVMe drives were detected.
 - Added --autoupdate=[age] option to auto update synology_hdd_db x days after new version released.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v2.3.53
+v2.3.54
 - Fixed HDD/SSD firmware versions always being 4 characters long (for DSM 7.2 and 6.2.4 Update 7).
 - Fixed detecting amount of installed memory (for DSM 7.2 which now reports GB instead of MB).
 - Fixed USB drives sometimes being detected as internal drives (for DSM 7.2).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v2.3.49
+v2.3.50
 - Fixed HDD/SSD firmware versions always being 4 characters long (for DSM 7.2 and 6.2.4 Update 7).
 - Fixed detecting amount of installed memory (for DSM 7.2 which now reports GB instead of MB).
 - Fixed USB drives sometimes being detected as internal drives (for DSM 7.2).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v2.3.52
+v2.3.53
 - Fixed HDD/SSD firmware versions always being 4 characters long (for DSM 7.2 and 6.2.4 Update 7).
 - Fixed detecting amount of installed memory (for DSM 7.2 which now reports GB instead of MB).
 - Fixed USB drives sometimes being detected as internal drives (for DSM 7.2).

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -178,7 +178,7 @@
 # Optionally disable "support_disk_compatibility".
 
 
-scriptver="v2.3.53"
+scriptver="v2.3.54"
 script=Synology_HDD_db
 repo="007revad/Synology_HDD_db"
 

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -36,7 +36,7 @@
 #
 # Fixed HDD/SSD firmware versions always being 4 characters long (for DSM 7.2 and 6.2.4 Update 7).
 #
-# Fixed detecting amount of installed memory (for DSM 7.2 which now reports GB instead of MB).
+# Fixed detecting the amount of installed memory (for DSM 7.2 which now reports GB instead of MB).
 #
 # Fixed USB drives sometimes being detected as internal drives (for DSM 7.2).
 #
@@ -178,7 +178,7 @@
 # Optionally disable "support_disk_compatibility".
 
 
-scriptver="v2.3.49"
+scriptver="v2.3.50"
 script=Synology_HDD_db
 repo="007revad/Synology_HDD_db"
 
@@ -628,19 +628,21 @@ getdriveinfo(){
     usb=$(grep "$(basename -- "$1")" /proc/mounts | grep "[Uu][Ss][Bb]" | cut -d" " -f1-2)
     if [[ ! $usb ]]; then
 
-        # Get drive model and firmware version
+        # Get drive model
         hdmodel=$(cat "$1/device/model")
         hdmodel=$(printf "%s" "$hdmodel" | xargs)  # trim leading and trailing white space
 
         # Fix dodgy model numbers
         fixdrivemodel "$hdmodel"
 
+        # Get drive firmware version
         #fwrev=$(cat "$1/device/rev")
         #fwrev=$(printf "%s" "$fwrev" | xargs)  # trim leading and trailing white space
 
-        #fwrev=$(syno_hdd_util --ssd_detect | grep "/dev/$d" | awk '{print $2}')      # GitHub issue #86, 87
+        device="/dev/$(basename -- "$1")"
+        #fwrev=$(syno_hdd_util --ssd_detect | grep "$device" | awk '{print $2}')      # GitHub issue #86, 87
         # Account for SSD drives with spaces in their model name/number
-        fwrev=$(syno_hdd_util --ssd_detect | grep "/dev/$d" | awk '{print $(NF-3)}')  # GitHub issue #86, 87
+        fwrev=$(syno_hdd_util --ssd_detect | grep "$device" | awk '{print $(NF-3)}')  # GitHub issue #86, 87
 
         if [[ $hdmodel ]] && [[ $fwrev ]]; then
             hdlist+=("${hdmodel},${fwrev}")

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -178,7 +178,7 @@
 # Optionally disable "support_disk_compatibility".
 
 
-scriptver="v2.3.50"
+scriptver="v2.3.51"
 script=Synology_HDD_db
 repo="007revad/Synology_HDD_db"
 

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -22,15 +22,13 @@
 #--------------------------------------------------------------------------------------------------
 
 # TODO
-# Bypass M.2 volume lock for unsupported M.2 drives. 
-#    See https://github.com/007revad/Synology_enable_M2_volume
-#
 # Maybe also edit the other disk compatibility db in synoboot, used during boot time.
 # It's also parsed and checked and probably in some cases it could be more critical to patch that one instead.
 #
 # Solve issue of --restore option restoring files that were backed up with older DSM version.
 
 # DONE
+# Changed the "No M.2 cards found" to "No M.2 PCIe cards found" to make it clearer.
 #
 # Added "You may need to reboot" message when NVMe drives were detected.
 #
@@ -178,7 +176,7 @@
 # Optionally disable "support_disk_compatibility".
 
 
-scriptver="v2.3.51"
+scriptver="v2.3.52"
 script=Synology_HDD_db
 repo="007revad/Synology_HDD_db"
 
@@ -811,9 +809,9 @@ fi
 # Check m2cards array isn't empty
 if [[ $m2 != "no" ]]; then
     if [[ ${#m2cards[@]} -eq "0" ]]; then
-        echo -e "No M.2 cards found\n"
+        echo -e "No M.2 PCIe cards found\n"
     else    
-        echo "M.2 card models found: ${#m2cards[@]}"
+        echo "M.2 PCIe card models found: ${#m2cards[@]}"
         num="0"
         while [[ $num -lt "${#m2cards[@]}" ]]; do
             echo "${m2cards[num]}"


### PR DESCRIPTION
v3.0.55
- Now enables any installed Synology M.2 PCIe cards for models that don't officially support them.
  - You can use a M2D20, M2D18, M2D17 or E10M20-T1 on any model with a PCIe slot (not Mini PCIe).
- Now the script reloads itself after updating.
- Added -i, --immutable option to enable immutable snapshots on models older than '20 series running DSM 7.2.
- Added -w, --wdda option to disable WDDA (to prevent warnings when WD drives have been running more than 3 years).
- Added "You may need to reboot" message when NVMe drives were detected.
- Added --autoupdate=[age] option to auto update synology_hdd_db x days after new version released.
    - Autoupdate logs update success or errors to DSM system log.
- Changed help to show -r, --ram also sets max memory to the amount of installed memory.
- Changed the "No M.2 cards found" to "No M.2 PCIe cards found" to make it clearer.
- Changed to skip checking the amount of installed memory in DSM 6 (because it was never working in DSM 6).
- Fixed HDD/SSD firmware versions always being 4 characters long (for DSM 7.2 and 6.2.4 Update 7).
- Fixed detecting amount of installed memory (for DSM 7.2 which now reports GB instead of MB).
- Fixed USB drives sometimes being detected as internal drives (for DSM 7.2).
- Fixed error if /run/synostorage/disks/nvme0n1/m2_pool_support doesn't exist yet (for DSM 7.2).
- Fixed drive db update still being disabled in /etc/synoinfo.conf after script run without -n or --noupdate option.
- Fixed drive db update still being disabled in /etc/synoinfo.conf after script run with --restore option.
- Fixed permissions on restored files being incorrect after script run with --restore option.
- Fixed permissions on backup files.