### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v3.4.76
+v3.4.77
 - Include smart_test_ignore and smart_attr_ignore in db files.
 - Now saves changes.txt as <script-filename>_changes.txt when updating the script.
     - To not overwrite changes.txt if my other scripts are in the same folder.

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -27,7 +27,7 @@
 # Now warns if script is located on an M.2 volume.
 
 
-scriptver="v3.4.76"
+scriptver="v3.4.77"
 script=Synology_HDD_db
 repo="007revad/Synology_HDD_db"
 scriptname=syno_hdd_db
@@ -1180,12 +1180,12 @@ updatedb(){
 # Fix ,, instead of , bug caused by v3.3.75
 if [[ "${#db1list[@]}" -gt "0" ]]; then
     for i in "${!db1list[@]}"; do
-        sed -i "s/,,/,/" 
+        sed -i "s/,,/,/"  "${db1list[i]}"
     done
 fi
 if [[ "${#db2list[@]}" -gt "0" ]]; then
     for i in "${!db2list[@]}"; do
-        sed -i "s/,,/,/" 
+        sed -i "s/,,/,/"  "${db2list[i]}"
     done
 fi
 


### PR DESCRIPTION
v3.4.77
- Include smart_test_ignore and smart_attr_ignore in db files.
- Now saves changes.txt as _changes.txt when updating the script.
- To not overwrite changes.txt if my other scripts are in the same folder.
- Bug fix for detecting if script is located on M.2 drive.
- Bug fix for error when -s or --showedits option was used. Issue https://github.com/007revad/Synology_HDD_db/issues/200
- Minor bug fix.