### PR TITLE
fix wrong uname 

### DIFF
--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -40,7 +40,7 @@ if [ ! "$(basename "$BASH")" = bash ]; then
 fi
 
 # Check script is running on a Synology NAS
-if ! uname -a | grep -i synology >/dev/null; then
+if ! /usr/bin/uname -a | grep -i synology >/dev/null; then
     echo "This script is NOT running on a Synology NAS!"
     echo "Copy the script to a folder on the Synology"
     echo "and run it from there."


### PR DESCRIPTION
replace `uname -a` with `/usr/bin/uname -a` to ensure it can get message like synology_denverton_2419+ or script will say is not synology NAS like in #217 
this will fix #217 