### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v3.5.90
+v3.5.90-RC
 - Changed to enable creating storage pools/volumes on NVMe drives in a PCIe M.2 adaptor in DSM 7.2
   - Previously only supported DSM 7.2.1
 - Changed to enable creating storage pools/volumes on NVMe drives in a PCIe M.2 adaptor even if PCIe M.2 adaptor not found.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,13 @@
+v3.5.90
+- Changed to enable creating storage pools/volumes on NVMe drives in a PCIe M.2 adaptor in DSM 7.2
+  - Previously only supported DSM 7.2.1
+- Changed to enable creating storage pools/volumes on NVMe drives in a PCIe M.2 adaptor even if PCIe M.2 adaptor not found.
+  - This may allow creating NVMe volumes on 3rd party PCIe M.2 adaptors.
+- Bug fix for when there's multiple expansion unit models only the last expansion unit was processed. Issue #288
+- Bug fix for when there's multiple M2 adaptor card models only the last M2 card was processed. 
+- Bug fix for incorrectly matching model name variations as well as the exact model name. 
+  - e.g. RX1217 matched RX1217, RX1217rp and RX1217sas.
+
 v3.5.89
 - Bug fix for -s, --showedits option with multiple of the same drive model but with different firmware versions. Issue #276
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v3.5.90-RC
+v3.5.90
 - Changed to enable creating storage pools/volumes on NVMe drives in a PCIe M.2 adaptor in DSM 7.2
   - Previously only supported DSM 7.2.1
 - Changed to enable creating storage pools/volumes on NVMe drives in a PCIe M.2 adaptor even if PCIe M.2 adaptor not found.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ There are optional flags you can use when running the script:
   -w, --wdda            Disable WD Device Analytics to prevent DSM showing
                         a false warning for WD drives that are 3 years old
                           DSM 7.2.1 already has WDDA disabled
-  -p, --pci             Enable creating volumes on M2 in unknown PCIe adaptor
+  -p, --pcie            Enable creating volumes on M2 in unknown PCIe adaptor
   -e, --email           Disable colored text in output scheduler emails
       --restore         Undo all changes made by the script
       --autoupdate=AGE  Auto update script (useful when script is scheduled)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ There are optional flags you can use when running the script:
   -w, --wdda            Disable WD Device Analytics to prevent DSM showing
                         a false warning for WD drives that are 3 years old
                           DSM 7.2.1 already has WDDA disabled
+  -p, --pci             Enable creating volumes on M2 in unknown PCIe adaptor
   -e, --email           Disable colored text in output scheduler emails
       --restore         Undo all changes made by the script
       --autoupdate=AGE  Auto update script (useful when script is scheduled)

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -1921,7 +1921,7 @@ fi
 # Enable creating pool on drives in M.2 adaptor card
 if [[ -f "$strgmgr" ]] && [[ $buildnumber -gt 42962 ]]; then
     # DSM 7.2 and later
-    #if [[ ${#m2cards[@]} -gt "0" ]]; then
+    if [[ ${#m2cards[@]} -gt "0" ]]; then
 
         if grep 'notSupportM2Pool_addOnCard' "$strgmgr" >/dev/null; then
             # Backup storage_panel.js"
@@ -1954,7 +1954,7 @@ if [[ -f "$strgmgr" ]] && [[ $buildnumber -gt 42962 ]]; then
         else
             echo -e "\nCreating pool in UI on drives in M.2 adaptor card already enabled."
         fi
-    #fi
+    fi
 fi
 
 

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -32,7 +32,7 @@
 # Hard coded /usr/syno/bin/<command> for Synology commands (to prevent $PATH issues).
 #
 # Now enables creating storage pools in Storage Manager for M.2 drives in PCIe adaptor cards.
-#  - E10M20-T1, M2D20, M2D18 and M2D17
+#  - E10M20-T1, M2D20, M2D18, M2D17 and FX2422N
 #
 # Added new vendor ids for Apacer, aigo, Lexar and Transcend NVMe drives.
 #
@@ -90,6 +90,7 @@ Options:
   -w, --wdda            Disable WD Device Analytics to prevent DSM showing
                         a false warning for WD drives that are 3 years old
                           DSM 7.2.1 already has WDDA disabled
+  -p, --pcie            Enable creating volumes on M2 in unknown PCIe adaptor
   -e, --email           Disable colored text in output scheduler emails
       --restore         Undo all changes made by the script
       --autoupdate=AGE  Auto update script (useful when script is scheduled)
@@ -119,7 +120,7 @@ args=("$@")
 
 # Check for flags with getopt
 if options="$(getopt -o abcdefghijklmnopqrstuvwxyz0123456789 -l \
-    restore,showedits,noupdate,nodbupdate,m2,force,incompatible,ram,wdda,email,autoupdate:,help,version,debug \
+    restore,showedits,noupdate,nodbupdate,m2,force,incompatible,ram,pcie,wdda,email,autoupdate:,help,version,debug \
     -- "$@")"; then
     eval set -- "$options"
     while true; do
@@ -148,6 +149,9 @@ if options="$(getopt -o abcdefghijklmnopqrstuvwxyz0123456789 -l \
                 ;;
             -w|--wdda)          # Disable "support_wdda"
                 wdda=no
+                ;;
+            -p|--pcie)          # Enable creating volumes on M2 in unknown PCIe adaptor
+                forcepci=yes
                 ;;
             -e|--email)         # Disable colour text in task scheduler emails
                 color=no
@@ -1921,7 +1925,7 @@ fi
 # Enable creating pool on drives in M.2 adaptor card
 if [[ -f "$strgmgr" ]] && [[ $buildnumber -gt 42962 ]]; then
     # DSM 7.2 and later
-    if [[ ${#m2cards[@]} -gt "0" ]]; then
+    if [[ ${#m2cards[@]} -gt "0" ]] || [[ $forcepci == "yes" ]]; then
 
         if grep 'notSupportM2Pool_addOnCard' "$strgmgr" >/dev/null; then
             # Backup storage_panel.js"


### PR DESCRIPTION
v3.5.90
- Changed to enable creating storage pools/volumes on NVMe drives in a PCIe M.2 adaptor in DSM 7.2
  - Previously only supported DSM 7.2.1
- Changed to enable creating storage pools/volumes on NVMe drives in a PCIe M.2 adaptor even if PCIe M.2 adaptor not found.
  - This may allow creating NVMe volumes on 3rd party PCIe M.2 adaptors.
- Bug fix for when there's multiple expansion unit models only the last expansion unit was processed. Issue #288
- Bug fix for when there's multiple M2 adaptor card models only the last M2 card was processed. 
- Bug fix for incorrectly matching model name variations as well as the exact model name. 
  - e.g. RX1217 matched RX1217, RX1217rp and RX1217sas.
