### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v3.5.91
+- Changed to not exit if no SATA or SAS drives found. Issue #303
+  - Now only exists if no SATA, SAS or NVMe drives found.
+
 v3.5.90
 - Changed to enable creating storage pools/volumes on NVMe drives in a PCIe M.2 adaptor in DSM 7.2
   - Previously only supported DSM 7.2.1

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -48,7 +48,7 @@
 # /var/packages/StorageManager/target/ui/storage_panel.js
 
 
-scriptver="v3.5.90"
+scriptver="v3.5.91"
 script=Synology_HDD_db
 repo="007revad/Synology_HDD_db"
 scriptname=syno_hdd_db
@@ -948,10 +948,9 @@ if [[ ${#hdlist[@]} -gt "0" ]]; then
     done < <(printf "%s\0" "${hdlist[@]}" | sort -uz)        
 fi
 
-# Check hdds array isn't empty
+# Show hdd if hdds array isn't empty
 if [[ ${#hdds[@]} -eq "0" ]]; then
-    ding
-    echo -e "\n${Error}ERROR${Off} No drives found!" && exit 2
+    echo -e "No SATA or SAS drives found\n"
 else
     echo -e "\nHDD/SSD models found: ${#hdds[@]}"
     num="0"
@@ -970,7 +969,7 @@ if [[ ${#nvmelist[@]} -gt "0" ]]; then
     done < <(printf "%s\0" "${nvmelist[@]}" | sort -uz)        
 fi
 
-# Check nvmes array isn't empty
+# Show nvmes if nvmes array isn't empty
 if [[ $m2 != "no" ]]; then
     if [[ ${#nvmes[@]} -eq "0" ]]; then
         echo -e "No M.2 drives found\n"
@@ -984,6 +983,13 @@ if [[ $m2 != "no" ]]; then
         done
         echo
     fi
+fi
+
+
+# Exit if no drives found
+if [[ ${#hdds[@]} -eq "0" ]] && [[ ${#nvmes[@]} -eq "0" ]]; then
+    ding
+    echo -e "\n${Error}ERROR${Off} No drives found!" && exit 2
 fi
 
 


### PR DESCRIPTION
v3.5.91
- Changed to not exit if no SATA or SAS drives found. Issue #303
  - Now only exists if no SATA, SAS or NVMe drives found.