### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v3.5.98
+- Changed to install dtc automaticall if needed and running from task scheduler.
+
 v3.5.97
 - Changed silently skip empty .db.new files with showing an error. Issue #175
 - Changed to warn if db file is 0 bytes.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ v3.5.98
     3. The script needs dtc.
     4. The script is running from task scheduler.
 - Bug fix for "Enable write_mostly on slow internal drives so DSM runs from the fast internal drive(s)." Issue #340
-- Improved output to make it clear which drive(s) have most-writly set.
+- Improved output to make it clear which drive(s) have most_writely set.
 
 v3.5.97
 - Changed silently skip empty .db.new files with showing an error. Issue #175

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ v3.5.98
     2. /bin/dtc or dtc are not in the same folder as the script.
     3. The script needs dtc.
     4. The script is running from task scheduler.
+- Bug fix for "Enable write_mostly on slow internal drives so DSM runs from the fast internal drive(s)." Issue #340
 
 v3.5.97
 - Changed silently skip empty .db.new files with showing an error. Issue #175

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 v3.5.98
-- Changed to install dtc automaticall if needed and running from task scheduler.
+- Changed to automatically download and install dtc if all of the following 4 conditions are met:
+    1. dtc is not already installed.
+    2. /bin/dtc or dtc are not in the same folder as the script.
+    3. The script needs dtc.
+    4. The script is running from task scheduler.
 
 v3.5.97
 - Changed silently skip empty .db.new files with showing an error. Issue #175

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ v3.5.98
     3. The script needs dtc.
     4. The script is running from task scheduler.
 - Bug fix for "Enable write_mostly on slow internal drives so DSM runs from the fast internal drive(s)." Issue #340
+- Improved output to make it clear which drive(s) have most-writly set.
 
 v3.5.97
 - Changed silently skip empty .db.new files with showing an error. Issue #175

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Thank you to the following PayPal donators, GitHub sponsors and hardware donator
 
 |  |  |  |  | 
 |--------------------|--------------------|----------------------|----------------------|
-|  | Sebastiaan Mulder | Nico Stark | Oleksandr Antonishak |
+| vaadmin | Sebastiaan Mulder | Nico Stark | Oleksandr Antonishak |
 | Marcel Siemienowski | Dave Smart | dweagle79 | lingyinsam | 
 | Vojtech Filkorn | Craig Sadler | Po-Chia Chen | Jean-François Fruhauf |
 | Sven 'ctraltdelete' | Thomas Horn | Christian | Simon Azzouni |

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -1730,31 +1730,36 @@ done
 set_writemostly(){ 
     # $1 is writemostly or in_sync
     # $2 is sata1 or sas1 or sda etc
+    local model
+    # Show drive model
+    model="$(cat /sys/block/"${2}"/device/model | xargs)"
+    echo -e "${Yellow}$model${Off}"
+
     if [[ ${1::2} == "sd" ]]; then
         # sda etc
         # md0 DSM system partition
         echo "$1" > /sys/block/md0/md/dev-"${2}"1/state
         # Show setting
-        echo -n "$2 DSM partition:  "
+        echo -n "  $2 DSM partition:  "
         cat /sys/block/md0/md/dev-"${2}"1/state
 
         # md1 DSM swap partition
         echo "$1" > /sys/block/md1/md/dev-"${2}"2/state
         # Show setting
-        echo -n "$2 Swap partition: "
+        echo -n "  $2 Swap partition: "
         cat /sys/block/md1/md/dev-"${2}"2/state
     else
         # sata1 or sas1 etc
         # md0 DSM system partition
         echo "$1" > /sys/block/md0/md/dev-"${2}"p1/state
         # Show setting
-        echo -n "$2 DSM partition:  "
+        echo -n "  $2 DSM partition:  "
         cat /sys/block/md0/md/dev-"${2}"p1/state
 
         # md1 DSM swap partition
         echo "$1" > /sys/block/md1/md/dev-"${2}"p2/state
         # Show setting
-        echo -n "$2 Swap partition: "
+        echo -n "  $2 Swap partition: "
         cat /sys/block/md1/md/dev-"${2}"p2/state
     fi
 }
@@ -1765,7 +1770,7 @@ if [[ $ssd == "yes" ]]; then
 
     if [[ $ssd_restore == "yes" ]]; then
         # Restore all internal drives to just in_sync
-        echo -e "\nRestoring internal drive's state:"
+        echo -e "\nRestoring internal drive's state"
         for idrive in "${internal_drives[@]}"; do
             #if ! grep -q "write_mostly"; then 
                 set_writemostly -writemostly "$idrive"
@@ -1774,7 +1779,7 @@ if [[ $ssd == "yes" ]]; then
 
     elif [[ ${#ssds_writemostly[@]} -gt "0" ]]; then
         # User specified their fast drive(s)
-        echo -e "\nSetting slow internal HDDs state to write_mostly:"
+        echo -e "\nSetting slow internal HDDs state to write_mostly"
         for idrive in "${internal_drives[@]}"; do
             if [[ ! ${ssds_writemostly[*]} =~ $idrive ]]; then
                 set_writemostly writemostly "$idrive"
@@ -1800,7 +1805,7 @@ if [[ $ssd == "yes" ]]; then
         # Set HDDs to writemostly if there's also internal SSDs
         if [[ $internal_ssd_qty -gt "0" ]] && [[ ${#internal_hdds[@]} -gt "0" ]]; then
             # There are internal SSDs and HDDs
-            echo -e "\nSetting internal HDDs state to write_mostly:"
+            echo -e "\nSetting internal HDDs state to write_mostly"
             for idrive in "${internal_hdds[@]}"; do
                 set_writemostly writemostly "$idrive"
             done

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -1785,13 +1785,12 @@ if [[ $ssd == "yes" ]]; then
         # Get list of internal HDDs and qty of SSDs
         internal_ssd_qty="0"
         for idrive in "${internal_drives[@]}"; do
-            internal_drive="$(echo "$idrive" | awk '{printf $4}')"
-            if synodisk --isssd "$internal_drive" >/dev/null; then
+            if synodisk --isssd /dev/"${idrive:?}" >/dev/null; then
                 # exit code 0 = is not SSD
                 # exit code 1 = is SSD
 
                 # Add internal HDDs to array
-                internal_hdds+=("$internal_drive")
+                internal_hdds+=("$idrive")
             else
                 # Count number of internal 2.5 inch SSDs
                 internal_ssd_qty=$((internal_ssd_qty +1))


### PR DESCRIPTION
v3.5.98
- Changed to automatically download and install dtc if all of the following 4 conditions are met:
    1. dtc is not already installed.
    2. /bin/dtc or dtc are not in the same folder as the script.
    3. The script needs dtc.
    4. The script is running from task scheduler.
- Bug fix for "Enable write_mostly on slow internal drives so DSM runs from the fast internal drive(s)." Issue #340
- Improved output to make it clear which drive(s) have most_writely set.