### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v3.5.99-RC
+- Changed to support "--restore --ssd=restore" to restore write_mostly when restoring all other changes. Issue #340
+
 v3.5.98
 - Changed to automatically download and install dtc if all of the following 4 conditions are met:
     1. dtc is not already installed.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v3.5.100-RC
+- Changed to support "--restore --ssd=restore" to restore write_mostly when restoring all other changes. Issue #340
+  - When using --restore you can also use --ssd=restore, -e or --email
+
 v3.5.99-RC
 - Changed to support "--restore --ssd=restore" to restore write_mostly when restoring all other changes. Issue #340
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,6 @@
-v3.5.100-RC
+v3.5.100
 - Changed to support "--restore --ssd=restore" to restore write_mostly when restoring all other changes. Issue #340
   - When using --restore you can also use --ssd=restore, -e or --email
-
-v3.5.99-RC
-- Changed to support "--restore --ssd=restore" to restore write_mostly when restoring all other changes. Issue #340
 
 v3.5.98
 - Changed to automatically download and install dtc if all of the following 4 conditions are met:

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Thank you to the following PayPal donators, GitHub sponsors and hardware donator
 
 |  |  |  |  | 
 |--------------------|--------------------|----------------------|----------------------|
+|  |  |  | Mark Rohde |
 | vaadmin | Sebastiaan Mulder | Nico Stark | Oleksandr Antonishak |
 | Marcel Siemienowski | Dave Smart | dweagle79 | lingyinsam | 
 | Vojtech Filkorn | Craig Sadler | Po-Chia Chen | Jean-François Fruhauf |

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -2090,8 +2090,7 @@ fi
 dtu=drive_db_test_url
 url="$(/usr/syno/bin/synogetkeyvalue $synoinfo ${dtu})"
 disabled=""
-#if [[ $nodbupdate == "yes" ]]; then
-if [[ $updatedb != "yes" ]]; then
+if [[ $nodbupdate == "yes" ]]; then
     if [[ ! $url ]]; then
         # Add drive_db_test_url="127.0.0.1"
         #echo 'drive_db_test_url="127.0.0.1"' >> "$synoinfo"

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -125,7 +125,7 @@ if options="$(getopt -o Sabcdefghijklmnopqrstuvwxyz0123456789 -l \
                 if $(echo "${args[@]}" | grep -q -- '--ssd=restore'); then
                     ssd_restore=yes
                 fi
-                break
+                #break
                 ;;
             -s|--showedits)     # Show edits done to host db file
                 showedits=yes


### PR DESCRIPTION
v3.5.100
- Changed to support "--restore --ssd=restore" to restore write_mostly when restoring all other changes. Issue #340
  - When using --restore you can also use --ssd=restore, -e or --email