### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v3.5.100
+v3.5.101
 - Changed to support "--restore --ssd=restore" to restore write_mostly when restoring all other changes. Issue #340
   - When using --restore you can also use --ssd=restore, -e or --email
 

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -29,7 +29,7 @@
 # /var/packages/StorageManager/target/ui/storage_panel.js
 
 
-scriptver="v3.5.100"
+scriptver="v3.5.101"
 script=Synology_HDD_db
 repo="007revad/Synology_HDD_db"
 scriptname=syno_hdd_db


### PR DESCRIPTION
v3.5.101
- Changed to support "--restore --ssd=restore" to restore write_mostly when restoring all other changes. Issue #340
  - When using --restore you can also use --ssd=restore, -e or --email