### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v3.5.102
+- Changed to use a faster method of detecting if an expansion unit is connected, for models with the syno_slot_mapping command.
+- Changed so XPE users using the hdddb addon don't need to reboot.
+
 v3.5.101
 - Changed to support "--restore --ssd=restore" to restore write_mostly when restoring all other changes. Issue #340
   - When using --restore you can also use --ssd=restore, -e or --email


### PR DESCRIPTION
v3.5.102
- Changed to use a faster method of detecting if an expansion unit is connected, for models with the syno_slot_mapping command.
- Changed so XPE users using the hdddb addon don't need to reboot.