### PR TITLE
get_size_gb() calculation error for 20GB HDDs.

### DIFF
--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -896,11 +896,9 @@ fixdrivemodel(){
 
 get_size_gb(){ 
     # $1 is /sys/block/sata1 or /sys/block/nvme0n1 etc
-    local float
-    local int
-    float=$(synodisk --info /dev/"$(basename -- "$1")" | grep 'Total capacity' | awk '{print $4 * 1.0737}')
-    int="${float%.*}"
-    echo "$int"
+    local disk_size_gb
+    disk_size_gb=$(synodisk --info /dev/"$(basename -- "$1")" | grep 'Total capacity' | awk '{print int($4 * 1.073741824)}')
+    echo "$disk_size_gb"
 }
 
 getdriveinfo(){ 


### PR DESCRIPTION
Increased precision of GiB to GB, 2^30 / 1e9 = 1.073741824

#368 