### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v3.5.104
+- Bug fix for drives that return "HCST <model>" as the model, like HGST drives do. Issue #389
+
 v3.5.103
 - Bug fix getting size of large drives. Issue #368
   - Run the script once with the --restore option to undue the previous changes then run the script as normal.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
-v3.5.104
+v3.5.105
 - Bug fix for drives that return "HCST <model>" as the model, like HGST drives do. Issue #389
+
+v3.5.104
+- Some disks will be blocked in special scenarios. PR #387
 
 v3.5.103
 - Bug fix getting size of large drives. Issue #368

--- a/syno_hdd_db.sh
+++ b/syno_hdd_db.sh
@@ -29,7 +29,7 @@
 # /var/packages/StorageManager/target/ui/storage_panel.js
 
 
-scriptver="v3.5.103"
+scriptver="v3.5.104"
 script=Synology_HDD_db
 repo="007revad/Synology_HDD_db"
 scriptname=syno_hdd_db
@@ -883,6 +883,9 @@ fixdrivemodel(){
         hdmodel=${hdmodel#"WDC "}       # Remove "WDC " from start of model name
         hdmodel=${hdmodel#"HGST "}      # Remove "HGST " from start of model name
         hdmodel=${hdmodel#"TOSHIBA "}   # Remove "TOSHIBA " from start of model name
+
+        # Chinese brand?
+        hdmodel=${hdmodel#"HCST "}      # Remove "HCST " from start of model name
 
         # Old drive brands
         hdmodel=${hdmodel#"Hitachi "}   # Remove "Hitachi " from start of model name


### PR DESCRIPTION
v3.5.104
- Bug fix for drives that return "HCST <model>" as the model, like HGST drives do. Issue #389